### PR TITLE
Add react-dom as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "docz-core": "^0.11.2",
     "react-art": "^16.5.0",
-    "react-native-web": "^0.8.9"
+    "react-native-web": "^0.9.6"
   },
   "devDependencies": {
     "libundler": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,12 @@
   },
   "dependencies": {
     "docz-core": "^0.11.2",
-    "react-art": "^16.5.0",
+    "react-art": "^16.5.1",
+    "react-dom": "^16.5.1",
     "react-native-web": "^0.9.6"
+  },
+  "peerDependencies": {
+    "react": ">=16.5.1"
   },
   "devDependencies": {
     "libundler": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5936,9 +5936,10 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-native-web@^0.8.9:
-  version "0.8.9"
-  resolved "https://registry.npmjs.org/react-native-web/-/react-native-web-0.8.9.tgz#0c616ce666a5547e2d850f15c2cc56abd14083ca"
+react-native-web@^0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.9.6.tgz#d51073963582b76775bcdff328aeee0fca807c99"
+  integrity sha512-i0tN/UCLNgsoFkoJOxCtW92L07A5XIJe6p2tlqF3/gdgBL4HK5m63fhc1Ywr1OoU/YJ59/Dnwz1VE/lak5ar3w==
   dependencies:
     array-find-index "^1.0.2"
     create-react-class "^15.6.2"


### PR DESCRIPTION
When using docz with react-native, I don't think we should force people to install `react-dom` separately. This PR includes `react-dom`, similar to how `react-art` is included.

If the maintainers feel `react-dom` should be managed as a separate dependency, we should at least update this error message and document the dependency in the README.md:

![image](https://user-images.githubusercontent.com/11021913/48228834-4d749e80-e374-11e8-931d-713a03f9622b.png)

_I don't think `react-dom/unstable-native-dependencies` can be installed separately, I believe it's just a submodule of react-dom_